### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,8 +18,6 @@
   "ignore": [
     "**/.*",
     "node_modules",
-    "bower_components",
-    "Gruntfile.js",
-    "package.json"
+    "bower_components"
   ]
 }


### PR DESCRIPTION
Removed the `gruntfile` and `package.json` from the ignore list, so they are included in the download from bower.